### PR TITLE
Add Frostium ore and snow biome generation

### DIFF
--- a/Content/Items/FrostiumOre.cs
+++ b/Content/Items/FrostiumOre.cs
@@ -1,0 +1,29 @@
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace xiwang.Content.Items
+{
+    public class FrostiumOre : ModItem
+    {
+        public override void SetStaticDefaults()
+        {
+            Item.ResearchUnlockCount = 100;
+        }
+
+        public override void SetDefaults()
+        {
+            Item.width = 12;
+            Item.height = 12;
+            Item.maxStack = 999;
+            Item.value = Item.sellPrice(silver: 2);
+            Item.useStyle = ItemUseStyleID.Swing;
+            Item.useTurn = true;
+            Item.useAnimation = 15;
+            Item.useTime = 10;
+            Item.autoReuse = true;
+            Item.consumable = true;
+            Item.createTile = ModContent.TileType<Tiles.FrostiumOre>();
+        }
+    }
+}

--- a/Content/Tiles/FrostiumOre.cs
+++ b/Content/Tiles/FrostiumOre.cs
@@ -1,0 +1,27 @@
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+namespace xiwang.Content.Tiles
+{
+    public class FrostiumOre : ModTile
+    {
+        public override void SetStaticDefaults()
+        {
+            Main.tileSolid[Type] = true;
+            Main.tileBlockLight[Type] = true;
+            Main.tileSpelunker[Type] = true;
+            Main.tileValue[Type] = 410;
+            Main.tileMergeDirt[Type] = true;
+
+            AddMapEntry(new Color(100, 200, 255), CreateMapEntryName());
+            DustType = DustID.Ice;
+            ItemDrop = ModContent.ItemType<Items.FrostiumOre>();
+            HitSound = SoundID.Tink;
+            MineResist = 4f;
+            MinPick = 65;
+        }
+    }
+}

--- a/xiwang.cs
+++ b/xiwang.cs
@@ -1,15 +1,36 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Terraria;
+using Terraria.ID;
+using Terraria.IO;
 using Terraria.ModLoader;
+using Terraria.WorldBuilding;
 
 namespace xiwang
 {
 	// Please read https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Modding-Guide#mod-skeleton-contents for more information about the various files in a mod.
-	public class xiwang : Mod
-	{
-
-	}
+    public class xiwang : Mod
+    {
+        public override void ModifyWorldGenTasks(List<GenPass> tasks, ref float totalWeight)
+        {
+            int shiniesIndex = tasks.FindIndex(genpass => genpass.Name.Equals("Shinies"));
+            if (shiniesIndex != -1)
+            {
+                tasks.Insert(shiniesIndex + 1, new PassLegacy("Frostium Ore", (progress, configuration) =>
+                {
+                    progress.Message = "Frostium Ore";
+                    int attempts = (int)((Main.maxTilesX * Main.maxTilesY) * 0.00008);
+                    for (int k = 0; k < attempts; k++)
+                    {
+                        int x = WorldGen.genRand.Next(0, Main.maxTilesX);
+                        int y = WorldGen.genRand.Next((int)WorldGen.rockLayerLow, Main.maxTilesY - 200);
+                        Tile tile = Framing.GetTileSafely(x, y);
+                        if (tile.TileType == TileID.SnowBlock || tile.TileType == TileID.IceBlock)
+                        {
+                            WorldGen.TileRunner(x, y, WorldGen.genRand.Next(3, 6), WorldGen.genRand.Next(3, 6), ModContent.TileType<Content.Tiles.FrostiumOre>());
+                        }
+                    }
+                }));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add FrostiumOre tile and associated item
- generate Frostium Ore veins in snow and ice during worldgen

## Testing
- `dotnet build` *(fails: Invalid framework identifier)*

------
https://chatgpt.com/codex/tasks/task_e_68bc768be698832aa672670cd001bcc0